### PR TITLE
Ignore pause-container images from scans

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -7,6 +7,6 @@ fi
 VERSION=$(cat "${SOURCE_PATH}/PAUSE_CONTAINER_VERSION")
 ${ADD_DEPENDENCIES_CMD} \
   --container-image-dependencies \
-  "{ \"name\": \"pause-container\", \"image_reference\": \"k8s.gcr.io/pause:${VERSION}\", \"version\": \"$VERSION\" }"
+  "{ \"name\": \"pause-container\", \"image_reference\": \"k8s.gcr.io/pause:${VERSION}\", \"version\": \"$VERSION\", \"labels\": [ { \"name\": \"cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1\", \"value\": { \"policy\": \"skip\", \"comment\": \"pause-container is not accessible from outside k8s clusters and not interacted with from other containers or other systems\" } } ] }"
 
 cp "${BASE_DEFINITION_PATH}" "${COMPONENT_DESCRIPTOR_PATH}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the component descriptor to enable ignoring of the pause-container images from vulnerability scans. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
"NONE"
```
